### PR TITLE
Fix publishing to npm by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - date
 
 install:
-  - npm install
+  - npm install --dev
   - npm run build
 script:
   - npm run test


### PR DESCRIPTION
Current issue when publishing to npm by travis:
```
NPM API key format changed recently. If your deployment fails, check your API key in ~/.npmrc.

http://docs.travis-ci.com/user/deployment/npm/

~/.npmrc size: 48

> @thehyve/fractalis@1.4.1-hyve prepublishOnly .

> npm run-script build && npm run-script create-es6-export-file

> @thehyve/fractalis@1.4.1-hyve build /home/travis/build/thehyve/Fractal.js

> webpack --config webpack.config.js --mode production

sh: 1: webpack: not found

npm ERR! file sh

npm ERR! code ELIFECYCLE

npm ERR! errno ENOENT
```

Hopefully installing dev dependencies will fix the issue...